### PR TITLE
fix: enum columns now generate random values instead of defaults

### DIFF
--- a/src/Services/SeederGenerator.php
+++ b/src/Services/SeederGenerator.php
@@ -681,7 +681,7 @@ PHP;
     $scale = $meta['scale'] ?? null;
 
         // respect explicit default values from schema metadata, but keep types
-        if (array_key_exists('default', $meta) && $meta['default'] !== null) {
+        if (array_key_exists('default', $meta) && $meta['default'] !== null && $type !== 'enum') {
             $def = $meta['default'];
             // normalize quoted defaults like '\'0\'' or '"fixed"'
             if (is_string($def)) {


### PR DESCRIPTION
- Fix SeederGenerator to skip enum columns from default value handling
- Enum columns now properly use random enum values from schema
- Previously enum columns were always using default values

Fixes issue where enum columns generated static default values instead of randomly selecting from available enum options.